### PR TITLE
Move type piracy of Base.schedule from API to SDK

### DIFF
--- a/src/api/src/common/context.jl
+++ b/src/api/src/common/context.jl
@@ -33,17 +33,3 @@ with_context(f, ctx::Context; kw...) =
 Return the `Context` associated with the caller's current execution unit.
 """
 current_context() = get(task_local_storage(), CONTEXT_KEY, Context())::Context
-
-# !!! intentional type piracy
-function Base.schedule(t::Task)
-    ctx = current_context()
-    if ctx !== Context()
-        if isnothing(t.storage)
-            t.storage = IdDict()
-        end
-        t.storage[CONTEXT_KEY] = ctx
-    end
-    Base.enq_work(t)
-end
-
-#####

--- a/src/sdk/src/patch.jl
+++ b/src/sdk/src/patch.jl
@@ -5,11 +5,11 @@
 
 function Base.schedule(t::Task)
     ctx = current_context()
-    if ctx !== Context()
+    if ctx !== OpenTelemetryAPI.Context()
         if isnothing(t.storage)
             t.storage = IdDict()
         end
-        t.storage[CONTEXT_KEY] = ctx
+        t.storage[OpenTelemetryAPI.CONTEXT_KEY] = ctx
     end
     Base.enq_work(t)
 end

--- a/src/sdk/src/patch.jl
+++ b/src/sdk/src/patch.jl
@@ -1,3 +1,23 @@
+#####
+# !!! intentional type piracy
+# https://github.com/oolong-dev/OpenTelemetry.jl/issues/32
+#####
+
+function Base.schedule(t::Task)
+    ctx = current_context()
+    if ctx !== Context()
+        if isnothing(t.storage)
+            t.storage = IdDict()
+        end
+        t.storage[CONTEXT_KEY] = ctx
+    end
+    Base.enq_work(t)
+end
+
+#####
+# GarishPrint
+#####
+
 function GarishPrint.pprint_struct(
     io::GarishPrint.GarishIO,
     mime::MIME"text/plain",


### PR DESCRIPTION
Thanks to @raffopazzo 's suggestion in https://github.com/oolong-dev/OpenTelemetry.jl/issues/32#issuecomment-1053989462