### PR TITLE
add compat for HTTP 1.x

### DIFF
--- a/src/exporter/otlp/proto/grpc/test/runtests.jl
+++ b/src/exporter/otlp/proto/grpc/test/runtests.jl
@@ -57,7 +57,7 @@ end
 end
 
 @testset "OtlpProtoGrpc Logs" begin
-    r = LogRecord(;
+    r = OpenTelemetryAPI.LogRecord(;
         timestamp = UInt(time() * 10^9),
         trace_id = INVALID_TRACE_ID,
         span_id = INVALID_SPAN_ID,

--- a/src/exporter/prometheus/Project.toml
+++ b/src/exporter/prometheus/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenTelemetryExporterPrometheus"
 uuid = "34e26579-e93c-4b5e-ba07-7afb633408c2"
 authors = ["Jun Tian <tianjun.cpp@gmail.com>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
@@ -9,7 +9,7 @@ OpenTelemetrySDK = "f5929ecf-be04-446c-b2f2-494e1fe70ee4"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
-HTTP = "0.9"
+HTTP = "0.9,1"
 OpenTelemetrySDK = "0.2.1"
 julia = "1"
 


### PR DESCRIPTION
Added compat for HTTP 1.x.
Does not seem to require any changes except in Project.toml.
Also bumped version, anticipating a patch release.