### PR TITLE
fix: switch off precompilation for OpenTelemetrySDK in Julia 1.10+

### DIFF
--- a/src/sdk/src/OpenTelemetrySDK.jl
+++ b/src/sdk/src/OpenTelemetrySDK.jl
@@ -18,6 +18,7 @@ using PackageExtensionCompat
 
 function __init__()
     @require_extensions
+    committypepiracy()
 end
 
 end # module

--- a/src/sdk/src/OpenTelemetrySDK.jl
+++ b/src/sdk/src/OpenTelemetrySDK.jl
@@ -1,5 +1,10 @@
 module OpenTelemetrySDK
 
+@static if VERSION >= v"1.10.0-alpha"
+    # https://github.com/oolong-dev/OpenTelemetry.jl/issues/93
+    __precompile__(false)
+end
+
 if !isdefined(Base, :get_extension)
     using Requires
 end
@@ -18,7 +23,6 @@ using PackageExtensionCompat
 
 function __init__()
     @require_extensions
-    committypepiracy()
 end
 
 end # module

--- a/src/sdk/src/patch.jl
+++ b/src/sdk/src/patch.jl
@@ -3,13 +3,15 @@
 # https://github.com/oolong-dev/OpenTelemetry.jl/issues/32
 #####
 
-function Base.schedule(t::Task)
-    ctx = current_context()
-    if ctx !== OpenTelemetryAPI.Context()
-        if isnothing(t.storage)
-            t.storage = IdDict()
+function committypepiracy()
+    @eval function Base.schedule(t::Task)
+        ctx = current_context()
+        if ctx !== OpenTelemetryAPI.Context()
+            if isnothing(t.storage)
+                t.storage = IdDict()
+            end
+            t.storage[OpenTelemetryAPI.CONTEXT_KEY] = ctx
         end
-        t.storage[OpenTelemetryAPI.CONTEXT_KEY] = ctx
+        Base.enq_work(t)
     end
-    Base.enq_work(t)
 end

--- a/src/sdk/src/patch.jl
+++ b/src/sdk/src/patch.jl
@@ -3,9 +3,13 @@
 # https://github.com/oolong-dev/OpenTelemetry.jl/issues/32
 #####
 
+const ayecaptain = Ref{Bool}(false)
+
 @static if VERSION >= v"1.10.0-alpha"
     function committypepiracy()
-        @eval function Base.schedule(t::Task)
+        ayecaptain[] && return
+        ayecaptain[] = true
+        Base.eval(Main, :(function Base.schedule(t::Task)
             ctx = current_context()
             if ctx !== OpenTelemetryAPI.Context()
                 if isnothing(t.storage)
@@ -14,7 +18,7 @@
                 t.storage[OpenTelemetryAPI.CONTEXT_KEY] = ctx
             end
             Base.enq_work(t)
-        end
+        end))
     end
 else
     committypepiracy() = nothing

--- a/src/sdk/src/patch.jl
+++ b/src/sdk/src/patch.jl
@@ -3,33 +3,15 @@
 # https://github.com/oolong-dev/OpenTelemetry.jl/issues/32
 #####
 
-const ayecaptain = Ref{Bool}(false)
+import Base
 
-@static if VERSION >= v"1.10.0-alpha"
-    function committypepiracy()
-        ayecaptain[] && return
-        ayecaptain[] = true
-        Base.eval(Main, :(function Base.schedule(t::Task)
-            ctx = current_context()
-            if ctx !== OpenTelemetryAPI.Context()
-                if isnothing(t.storage)
-                    t.storage = IdDict()
-                end
-                t.storage[OpenTelemetryAPI.CONTEXT_KEY] = ctx
-            end
-            Base.enq_work(t)
-        end))
-    end
-else
-    committypepiracy() = nothing
-    function Base.schedule(t::Task)
-        ctx = current_context()
-        if ctx !== OpenTelemetryAPI.Context()
-            if isnothing(t.storage)
-                t.storage = IdDict()
-            end
-            t.storage[OpenTelemetryAPI.CONTEXT_KEY] = ctx
+function Base.schedule(t::Task)
+    ctx = current_context()
+    if ctx !== OpenTelemetryAPI.Context()
+        if isnothing(t.storage)
+            t.storage = IdDict()
         end
-        Base.enq_work(t)
+        t.storage[OpenTelemetryAPI.CONTEXT_KEY] = ctx
     end
+    Base.enq_work(t)
 end

--- a/src/sdk/src/patch.jl
+++ b/src/sdk/src/patch.jl
@@ -3,8 +3,22 @@
 # https://github.com/oolong-dev/OpenTelemetry.jl/issues/32
 #####
 
-function committypepiracy()
-    @eval function Base.schedule(t::Task)
+@static if VERSION >= v"1.10.0-alpha"
+    function committypepiracy()
+        @eval function Base.schedule(t::Task)
+            ctx = current_context()
+            if ctx !== OpenTelemetryAPI.Context()
+                if isnothing(t.storage)
+                    t.storage = IdDict()
+                end
+                t.storage[OpenTelemetryAPI.CONTEXT_KEY] = ctx
+            end
+            Base.enq_work(t)
+        end
+    end
+else
+    committypepiracy() = nothing
+    function Base.schedule(t::Task)
         ctx = current_context()
         if ctx !== OpenTelemetryAPI.Context()
             if isnothing(t.storage)


### PR DESCRIPTION
"fixes": https://github.com/oolong-dev/OpenTelemetry.jl/issues/93

~This moves the type piracy of the `Base.schedule` at runtime, to provide compatibility with Julia 1.10.~

This disables precompilation for OpenTelemetrySDK for recent versions of Julia, as per https://docs.julialang.org/en/v1/manual/modules/#Module-initialization-and-precompilation

Sysimages will break! 

The final fix will probably be something else, but I'm adding that here for raising awareness.

Tests pass, but I'm probably missing something (I'm learning about OpenTelemetry as we speak! super nice talk at JuliaCon btw 🤗)