### PR TITLE
Enable manual management of Span lifecycle

### DIFF
--- a/src/api/src/trace/tracer_provider.jl
+++ b/src/api/src/trace/tracer_provider.jl
@@ -297,7 +297,7 @@ Here we follow the [Behavior of the API in the absence of an installed SDK](http
 """
 function create_span(
     name::String,
-    tracer::Tracer{DummyTracerProvider} = Tracer();
+    tracer::Tracer{DummyTracerProvider};
     context::Context = current_context(),
     parent_span::Union{Nothing,AbstractSpan} = current_span(context),
     parent_span_ctx::Union{Nothing,SpanContext} = span_context(parent_span),
@@ -311,6 +311,9 @@ function create_span(
         parent_span
     end
 end
+
+# To avoid default argument implementation that causes redifinitions
+create_span(name::String; kwargs...) = create_span(name, Tracer(); kwargs...)
 
 """
     with_span(f, name::String, [tracer=Tracer()]; kw...)

--- a/src/sdk/src/trace/sampling.jl
+++ b/src/sdk/src/trace/sampling.jl
@@ -51,7 +51,7 @@ end
 
 ## Arguments
 
-  - `parent_context`::[`Context`](@ref),
+  - `parent_span_ctx`::[`SpanContext`](@ref),
   - `trace_id`::[`TraceIdType`](@ref),
   - `name::String`, the span name
   - `kind`::[`SpanKind`](@ref),
@@ -63,7 +63,7 @@ function should_sample end
 
 function should_sample(
     s::StaticSampler,
-    parent_context,
+    parent_span_ctx,
     trace_id,
     name,
     kind = SPAN_KIND_INTERNAL,
@@ -88,7 +88,7 @@ end
 
 function should_sample(
     s::TraceIdRatioBased,
-    parent_context,
+    parent_span_ctx,
     trace_id,
     name,
     kind = SPAN_KIND_INTERNAL,
@@ -116,7 +116,7 @@ end
 
 function should_sample(
     s::ParentBasedSampler,
-    parent_context,
+    parent_span_ctx,
     trace_id,
     name,
     kind = SPAN_KIND_INTERNAL,
@@ -124,7 +124,6 @@ function should_sample(
     links = [],
     trace_state = TraceState(),
 )
-    parent_span_ctx = parent_context |> current_span |> span_context
     sampler = s.root_sampler
     if !isnothing(parent_span_ctx)
         if parent_span_ctx.is_remote
@@ -143,7 +142,7 @@ function should_sample(
     end
     should_sample(
         sampler,
-        parent_context,
+        parent_span_ctx,
         trace_id,
         name,
         kind,

--- a/src/sdk/src/trace/span.jl
+++ b/src/sdk/src/trace/span.jl
@@ -66,7 +66,7 @@ end
 
 function OpenTelemetryAPI.create_span(
     name::String,
-    tracer::Tracer{<:TracerProvider} = Tracer();
+    tracer::Tracer{<:TracerProvider};
     context::OpenTelemetryAPI.Context = current_context(),
     parent_span::Union{Nothing,AbstractSpan} = current_span(context),
     parent_span_ctx::Union{Nothing,SpanContext} = span_context(parent_span),

--- a/src/sdk/src/trace/span.jl
+++ b/src/sdk/src/trace/span.jl
@@ -66,9 +66,10 @@ end
 
 function OpenTelemetryAPI.create_span(
     name::String,
-    tracer::Tracer{<:TracerProvider};
+    tracer::Tracer{<:TracerProvider} = Tracer();
     context::OpenTelemetryAPI.Context = current_context(),
-    parent_span_ctx::Union{Nothing,SpanContext} = span_context(current_span(context)),
+    parent_span::Union{Nothing,AbstractSpan} = current_span(context),
+    parent_span_ctx::Union{Nothing,SpanContext} = span_context(parent_span),
     trace_id::Union{Nothing, TraceIdType} = nothing,
     kind = SPAN_KIND_INTERNAL,
     attributes = Dict{String,OpenTelemetryAPI.TAttrVal}(),


### PR DESCRIPTION
The rationale here is that I could not create Spans with predefined `trace_id` easily. 
This is to cover the distributed case where I get a `trace_id` from an external system

When I added the capability to create spans I had to add ways to actually use them, so modified `with_span` etc. a bit.
Lots of things were already there, so just filling in the gaps.

Also fixes some redefinitions which appear after the schedule Task fix here https://github.com/oolong-dev/OpenTelemetry.jl/pull/97/commits/323fd55d84da28efca87ef6f12983221fa67c888
So it partially fixes https://github.com/oolong-dev/OpenTelemetry.jl/issues/93 


Example:

```julia
# create a span with `trace_id` linked to a previous span with `span_id`
function otel_create_span(
    name::AbstractString,
    trace_id::UInt128,
    link_span_id::UInt64,
)
    link_sc = SpanContext(;
        span_id=link_span_id,
        trace_id,
        is_remote=true,
    )
    l1 = Link(link_sc, BoundedAttributes())
    s = create_span(
        name;
        trace_id,
        links=Link[l1],
    )
    return s::Span
end

```