### PR TITLE
fix: http trace exporter fix network byte order on little endian machines

### DIFF
--- a/src/exporter/otlp/proto/http/Project.toml
+++ b/src/exporter/otlp/proto/http/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenTelemetryExporterOtlpProtoHttp"
 uuid = "f175482f-0544-4037-b362-361efbf21c04"
 authors = ["Jun Tian <tianjun.cpp@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"


### PR DESCRIPTION
Noticed that the span and trace ids were reversed once uploaded to the collector
Turns out we assumed endianess of the machine, so on big endian it (would) work fine, but on little endian the bytes were reversed

we need to use `hton` to convert machine endianess to network order

example
```
julia> reinterpret(UInt8, [0x18178a164dff94cc2d9651beb5749db7])
16-element reinterpret(UInt8, ::Vector{UInt128}):
 0xb7
 0x9d
 0x74
 0xb5
 0xbe
 0x51
 0x96
 0x2d
 0xcc
 0x94
 0xff
 0x4d
 0x16
 0x8a
 0x17
 0x18

julia> reinterpret(UInt8, [hton(0x18178a164dff94cc2d9651beb5749db7)]) 
16-element reinterpret(UInt8, ::Vector{UInt128}):
 0x18
 0x17
 0x8a
 0x16
 0x4d
 0xff
 0x94
 0xcc
 0x2d
 0x96
 0x51
 0xbe
 0xb5
 0x74
 0x9d
 0xb7



```