### PR TITLE
Improve printing of backtrace in log message

### DIFF
--- a/src/exporter/otlp/proto/http/src/OpenTelemetryExporterOtlpProtoHttp.jl
+++ b/src/exporter/otlp/proto/http/src/OpenTelemetryExporterOtlpProtoHttp.jl
@@ -95,7 +95,7 @@ function SDK.export!(x::OtlpHttpExporter{Req,Resp}, batch::Union{AbstractVector,
         @error(
             "Error in OtlpHttpExporter, the attempted batch export failed and will not be retried anymore. " *
             "The batch will not be returned to the queue either.",
-            exception=(ex, catch_backtrace())
+            exception=(ex, stacktrace(catch_backtrace()))
         )
         return SDK.EXPORT_FAILURE
     end


### PR DESCRIPTION
The output of `catch_backtrace()` will be shown as raw pointers when being serialized (e.g. when looking at logs in Sentry). This can be avoided by wrapping it in `stacktrace`.