### PR TITLE
Bump OpenTelemetryExporterOtlpProtoHttp to 0.1.6

### DIFF
--- a/src/exporter/otlp/proto/http/Project.toml
+++ b/src/exporter/otlp/proto/http/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenTelemetryExporterOtlpProtoHttp"
 uuid = "f175482f-0544-4037-b362-361efbf21c04"
 authors = ["Jun Tian <tianjun.cpp@gmail.com>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"


### PR DESCRIPTION
## Summary
- Patch version bump for `OpenTelemetryExporterOtlpProtoHttp`: `0.1.5` → `0.1.6`
- Follows #124 (improve backtrace printing in log message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)