### PR TITLE
fix: HEADERS env parsing incorrectly splitting on `=`

### DIFF
--- a/src/api/src/utils.jl
+++ b/src/api/src/utils.jl
@@ -6,7 +6,7 @@ using Logging
 """
 Turn `"a=b,c=d"` into a `NamedTuple`
 """
-extract_attrs(s) = NamedTuple(let (k, v) = split(kv, '=')
+extract_attrs(s) = NamedTuple(let (k, v) = split(kv, '=', limit=2)
     Symbol(k) => v
 end for kv in split(s, ',') if !isempty(kv))
 


### PR DESCRIPTION
PR sets `limit=1` in the split call done in `extract_attrs`. Without the limit, this causes issues when parsing strings that contain multiple `=` as part of their value.

Ran into an issue while setting things up to export to OpenObserve. It requires basic auth in the headers, containing a base64 encoded string, and base64 uses `=` for padding.

```julia
julia> header_val = "Authorization=Basic xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==,stream=foo"
"Authorization=Basic xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==,stream=foo"

julia> header_parts = split(header_val, ",")
2-element Vector{SubString{String}}:
 "Authorization=Basic xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=="
 "stream=foo"

julia> split(header_parts[1], '=')
4-element Vector{SubString{String}}:
 "Authorization"
 "Basic xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ""
 ""

julia> split(header_parts[1], '=', limit=2)
2-element Vector{SubString{String}}:
 "Authorization"
 "Basic xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=="
```

Without `limit=2` the value is split into 4 elements, which becomes `(Authorization = "Basic xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")`, effectively stripping off the final two `==`, which causes authorization checks to fail due to the incorrect value.