### PR TITLE
Bump OpenTelemetryAPI to 0.5.3

### DIFF
--- a/src/api/Project.toml
+++ b/src/api/Project.toml
@@ -1,7 +1,7 @@
 name = "OpenTelemetryAPI"
 uuid = "4f63ef3d-5940-44e7-a611-2d97696cffc9"
 authors = ["Jun Tian <tianjun.cpp@gmail.com>"]
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
## Summary
- Bumps `OpenTelemetryAPI` from `0.5.2` to `0.5.3` to release the `HEADERS` env parsing fix from #126 (`split(..., '=', limit=2)` so base64 `==` padding is preserved).

## Test plan
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)